### PR TITLE
Use event.key instead of deprecated event.keyIdentifier

### DIFF
--- a/lib/client/console.js
+++ b/lib/client/console.js
@@ -363,7 +363,7 @@ var $, io, skipfirst;
         function fromCharCode(event) {
             var code, hex,
                 char        = '',
-                identifier  = event.keyIdentifier,
+                identifier  = event.keyIdentifier || event.key,
                 shift       = event.shiftKey;
                 
             if (identifier === 'Enter') {

--- a/modules/skipfirst/README.md
+++ b/modules/skipfirst/README.md
@@ -30,7 +30,7 @@ var skipfirst   = require('skipfirst'),
  */
 document.body.addEventListener('keydown', function(event) {
     var key         = event.keyCode,
-        identifier  = event.keyIdentifier,
+        identifier  = event.keyIdentifier || event.key,
         ENTER       = 13,
         ESC         = 27;
     


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyIdentifier, `event.keyIdentifier` is deprecated in favor of `event.key`. This throws an exception when I try to run the console inside Firefox.
